### PR TITLE
Fixed bug: Friends drop down list showing all users in database

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -334,7 +334,9 @@ def visualisation():
     Render the visualisation page.
     Displays a list of friends and their calendar event durations.
     """
-    friends = User.query.filter(User.id != current_user.id).all()  
+    friendships = Friendship.query.filter_by(user_id=current_user.id, status='accepted').all()
+    friends = [User.query.get(f.friend_id) for f in friendships]
+
     return render_template('visualisation.html', friends=friends, event_durations={})
 
 @main.route('/api/friend_calendar/<int:friend_id>')


### PR DESCRIPTION
Hey all, 

This is a fix regarding issue #119.

Here's the following work that I've done:
- Modified the route for visualisation(), where previously it only took in the relationship that all "users" in the database. Instead, tweaked the code to show relationship that users must be "friends". 

Screenshot of fix working:
- Now, it will only show the calendar for only those who are friends. 
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/20c41bdd-03ab-40ce-9f82-392f5c930e75" />

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/1c4864d2-7a26-4275-aa42-08a4aea4aabf" />
